### PR TITLE
TxreceiptStatus should be nullable

### DIFF
--- a/Etherscan.NetSDK/Models/EtherscanTransaction.cs
+++ b/Etherscan.NetSDK/Models/EtherscanTransaction.cs
@@ -1,4 +1,4 @@
-﻿using DotNetToolkit;
+using DotNetToolkit;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -48,6 +48,6 @@ namespace Etherscan.NetSDK.Models
         /// <summary>
         /// 1 = Success
         /// </summary>
-        public int TxreceiptStatus { get; set; }
+        public int? TxreceiptStatus { get; set; }
     }
 }


### PR DESCRIPTION
According to the docs:
[BETA] Check Transaction Receipt Status (Only applicable for Post Byzantium fork transactions)
Note: status: 0 = Fail, 1 = Pass. Will return null/empty value for pre-byzantium fork

Saw this fixed in the fork, but not in the nuget package.